### PR TITLE
 Target release_ios_bundle_flutter_assets failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .pub-cache/
 .pub/
 build/
+pubspec.lock
 
 # Android related
 **/android/**/gradle-wrapper.jar

--- a/lib/src/apple_icon.dart
+++ b/lib/src/apple_icon.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class IconApple {
-  static final apple = IconData(
+  static final apple = const IconData(
     0xeabe,
     fontFamily: 'appleicon',
     fontPackage: 'device_simulator',


### PR DESCRIPTION
Here is the error that this PR resolves (shown during "flutter build ios") using Flutter (Channel beta, 1.19.0-4.1.pre, on Mac OS X 10.15.5 19F101, locale en-CA):

This application cannot tree shake icons fonts. It has non-constant instances of IconData at the following
    locations:
      -
      file:///Users/chris/projects/flutter/.pub-cache/hosted/pub.dartlang.org/device_simulator-0.9.6/lib/src/**apple_icon.dart:4:24**
    Target release_ios_bundle_flutter_assets failed: Exception: Avoid non-constant invocations of IconData or try to build again with --no-tree-shake-icons.
    build failed.